### PR TITLE
relax faraday_middleware dependency

### DIFF
--- a/profitrolly.gemspec
+++ b/profitrolly.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'sinatra', '~> 1.4'
 
   spec.add_dependency 'faraday', '~> 0.9'
-  spec.add_dependency 'faraday_middleware', '~> 0.9'
+  spec.add_dependency 'faraday_middleware', '>= 0.9.1'
 end


### PR DESCRIPTION
Надо разрешить использовать более новые версии `faraday_middleware`, там уже 0.10 вышел.
